### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,16 @@ You need to have it installed globally for Pymodoro to work correcty.
 $ npm i -g macos-focus-mode
 ```
 
+If you encounter this error:
+`import _tkinter # If this fails your Python may not be configured for Tk`
+This project also requires `tkinter`
+
+You can install it with homebrew
+
+```
+$ brew install python-tk
+```
+
 #### Python 3
 
 To run Pymodoro you need to have [Python 3 installed](https://www.python.org/downloads/).


### PR DESCRIPTION
When I run: `python3 pymodoro.py 25`                                                                                                                                                                                                                                                                                                                   I got the following error:
Traceback (most recent call last):
  File "~/projects/pymodoro/pymodoro.py", line 5, in <module>
    import tkinter as tk
  File "/opt/homebrew/Cellar/python@3.12/3.12.3/Frameworks/Python.framework/Versions/3.12/lib/python3.12/tkinter/__init__.py", line 38, in <module>
    import _tkinter # If this fails your Python may not be configured for Tk
    ^^^^^^^^^^^^^^^
ModuleNotFoundError: No module named '_tkinter'

Fixed by installing python-tk. Updated readme how to do this.